### PR TITLE
Implement Light and Dark modes feature #1

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React</title>
   </head>
-  <body>
+  <body className="">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/src/components/grid/Grid.css
+++ b/src/components/grid/Grid.css
@@ -1,25 +1,44 @@
-
+/* css for Light mode */
 table {
-    border-collapse: collapse;
-    font-size: 2em;
-    margin: 0 auto;
-    border: solid 4px #6e4102;
-    margin-top: 1.5rem;
-    margin-bottom: 1.5rem;
+  border-collapse: collapse;
+  font-size: 2em;
+  margin: 0 auto;
+  border: solid 4px #6e4102;
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
 }
 
 colgroup,
 tbody {
-    border: solid medium #6e4102;
+  border: solid medium #6e4102;
 }
 
 td {
-    border: solid thin #6e4102;
-    height: 1.4em;
-    width: 1.4em;
-    text-align: center;
-    padding: 0;
-    background-color: #FCCD90;
-    /* background-color: #FF9F1C; */
-    color: black;
+  border: solid thin #6e4102;
+  height: 1.4em;
+  width: 1.4em;
+  text-align: center;
+  padding: 0;
+  background-color: #fccd90;
+  /* background-color: #FF9F1C; */
+  color: black;
+}
+
+/* css for Dark mode */
+table.dark-mode {
+  border: solid 4px #daf4ff;
+}
+
+table.dark-mode colgroup,
+table.dark-mode tbody {
+  border: solid medium #daf4ff;
+}
+
+table.dark-mode td {
+  border: solid thin #daf4ff;
+  height: 1.4em;
+  width: 1.4em;
+  text-align: center;
+  padding: 0;
+  color: rgb(255, 255, 255);
 }

--- a/src/components/grid/Grid.jsx
+++ b/src/components/grid/Grid.jsx
@@ -23,7 +23,7 @@ const Grid = ({ grid, onChange, canEdit }) => {
     tBodies.push(<tbody key={i}>{tBody}</tbody>);
   }
   return (
-    <table>
+    <table className="">
       <colgroup>
         <col></col>
         <col></col>

--- a/src/components/sudokuSolver/SudokuSolver.css
+++ b/src/components/sudokuSolver/SudokuSolver.css
@@ -1,8 +1,8 @@
-.row{
-    display: flex;
-    flex-direction: row;
+.row {
+  display: flex;
+  flex-direction: row;
 }
-h1{
-    font-size: 3.5rem;
-    margin-bottom: 1.1rem;
+h1 {
+  font-size: 3.5rem;
+  margin-bottom: 1.1rem;
 }

--- a/src/components/sudokuSolver/SudokuSolver.jsx
+++ b/src/components/sudokuSolver/SudokuSolver.jsx
@@ -2,7 +2,7 @@ import "./SudokuSolver.css";
 
 import { getInitialGrid, gridSize, puzzles } from "../../algorithms/gridAlgo";
 import Grid from "../grid/Grid";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { solve } from "../../algorithms/solve";
 
 const validNum = /[1-9]/;
@@ -120,17 +120,61 @@ const SudokuSolver = () => {
     else solveSudoku();
   };
 
+  // code for Dark mode
+  const [isDarkMode, setIsDarkMode] = useState(false);
+
+  useEffect(() => {
+    const darkMode = localStorage.getItem("darkMode") === "true";
+    setIsDarkMode(darkMode);
+    if (darkMode) {
+      document.body.classList.add("dark-mode");
+      const table = document.querySelector("table");
+      if (table) {
+        table.classList.add("dark-mode");
+      }
+      const buttons = document.querySelectorAll(".button");
+      buttons.forEach((button) => {
+        button.classList.add("dark-mode");
+      });
+    }
+  }, []);
+
+  const toggleDarkMode = () => {
+    setIsDarkMode((prevMode) => {
+      const newMode = !prevMode;
+      document.body.classList.toggle("dark-mode", newMode);
+      const table = document.querySelector("table");
+      if (table) {
+        table.classList.toggle("dark-mode", newMode);
+      }
+      const buttons = document.querySelectorAll(".button");
+      buttons.forEach((button) => {
+        button.classList.toggle("dark-mode", newMode);
+      });
+
+      // Lưu trạng thái vào localStorage
+      localStorage.setItem("darkMode", newMode);
+
+      return newMode;
+    });
+  };
+
   return (
     <>
       <h1>
         <span style={{ color: "yellow" }}>Sudoku </span>
         <span style={{ color: "#AAFF00" }}>Solver</span>
       </h1>
-      <div className="button" onClick={handleClick}>
-        {isSolved ? "Reset" : isSolving ? "Solving..." : "Solve"}
+      <div className="header">
+        <div className="button " onClick={toggleDarkMode}>
+          {isDarkMode ? "Light mode" : "Dark mode"}
+        </div>
+        <div className="button " onClick={handleClick}>
+          {isSolved ? "Reset" : isSolving ? "Solving..." : "Solve"}
+        </div>
       </div>
       <Grid grid={grid} onChange={onChange} canEdit={canEdit} />
-      <div className="button puzzle" onClick={getPuzzle}>
+      <div className="button puzzle " onClick={getPuzzle}>
         {isPuzzle ? "Change Puzzle" : "Get Puzzle"}
       </div>
     </>

--- a/src/index.css
+++ b/src/index.css
@@ -27,7 +27,27 @@ body {
   background-color: #472902;
   cursor: pointer;
   transition: border-color 0.25s;
+  margin: 10px;
 }
 .button:hover {
   border-color: #646cff;
+}
+
+/* css for Dark mode */
+body.dark-mode {
+  background-color: rgba(5, 21, 40, 0.704);
+  color: white;
+}
+
+div.dark-mode {
+  background-color: #366ef1;
+}
+div.dark-mode:hover {
+  border-color: #ffffff;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }


### PR DESCRIPTION
I implemented dark mode functionality in the Sudoku Solver by creating a separate CSS class for dark mode styles and adding a state variable `isDarkMode` to manage its status. A `toggleDarkMode` function was introduced to switch between light and dark modes, applying the appropriate styles to the body, table, and buttons. Additionally, we utilized `localStorage` to persist the user's dark mode preference, ensuring it remains consistent across sessions. A button was added in the header to allow users to toggle between modes easily. You can check it out, hope you like it.